### PR TITLE
simplifed redis code removing pubsub object

### DIFF
--- a/src/_test/mocks.py
+++ b/src/_test/mocks.py
@@ -6,10 +6,10 @@ from arroyo.schemas import Message
 class MockOperator(Operator):
     def __init__(self, publisher: Publisher):
         super().__init__()
-        self.publisher = publisher
+        self.publishers = publisher
 
     def process(self, data: Message) -> None:
-        self.publisher.publish(data)
+        self.publishers.publish(data)
 
 
 class MockPublisher(Publisher):

--- a/src/_test/test_redis.py
+++ b/src/_test/test_redis.py
@@ -4,50 +4,49 @@ import fakeredis.aioredis as redis
 import pytest
 import pytest_asyncio
 
-from arroyo.redis import RedisListener, REDIS_CHANNEL_NAME
+from arroyo.redis import RedisListener, RedisPublisher
 
+REDIS_CHANNEL_NAME = b"arroyo"
 
 @pytest_asyncio.fixture
 async def redis_client():
     client = await redis.FakeRedis()
     yield client
-    await client.wait_closed()
+    await client.aclose()
 
 
 @pytest_asyncio.fixture
-async def redis_pub_sub(redis_client: redis.FakeRedis):
-    redis_pub_sub = redis_client.pubsub()
-    await redis_pub_sub.subscribe(REDIS_CHANNEL_NAME)
-    yield redis_pub_sub
-    await redis_pub_sub.close()
-
-
-@pytest_asyncio.fixture
-async def redis_listener(operator_mock, redis_client, redis_pub_sub):
+async def redis_listener(operator_mock, redis_client):
     listener = RedisListener(
-        operator=operator_mock,
         redis_client=redis_client,
-        redis_pubsub=redis_pub_sub)
-    await redis_pub_sub.subscribe(REDIS_CHANNEL_NAME)  # Subscribe to the channel
+        redis_channel_name=REDIS_CHANNEL_NAME,
+        operator=operator_mock)
+    yield listener
+    await listener.stop()
+
+
+@pytest_asyncio.fixture
+async def redis_publisher(operator_mock, redis_client, redis_channel_name):
+    listener = RedisPublisher(
+        operator=operator_mock,
+        redis_channel_name=redis_channel_name)
     yield listener
     await listener.stop()
 
 
 @pytest.mark.asyncio
-async def test_from_client(operator_mock, redis_client, redis_pub_sub):
+async def test_from_client(operator_mock, redis_client):
     listener = await RedisListener.from_client(
-                        operator=operator_mock,
                         redis_client=redis_client,
-                        redis_pub_sub=redis_pub_sub)
+                        redis_channel_name=REDIS_CHANNEL_NAME,
+                        operator=operator_mock)
 
-    assert listener.operator == operator_mock
     assert listener.redis_client == redis_client
-    assert listener.redis_pub_sub == redis_pub_sub
-    assert REDIS_CHANNEL_NAME in redis_pub_sub.channels.keys()  # Ensure the channel was subscribed
+    assert listener.redis_channel_name == REDIS_CHANNEL_NAME
 
 
 @pytest.mark.asyncio
-async def test_redis(redis_listener, redis_pub_sub, redis_client, operator_mock):
+async def test_redis(redis_listener, redis_client, operator_mock):
     # Arrange
     async def send_messages():
         await asyncio.sleep(0.1)  # Give some time for the listener to start
@@ -55,7 +54,6 @@ async def test_redis(redis_listener, redis_pub_sub, redis_client, operator_mock)
         await asyncio.sleep(0.1)
         await redis_client.publish(REDIS_CHANNEL_NAME, b"message2")
         await asyncio.sleep(0.1)
-        await redis_pub_sub.unsubscribe(REDIS_CHANNEL_NAME)  # Unsubscribe to stop the listener
         await redis_listener.stop()
 
     listener_task = asyncio.create_task(redis_listener.start())

--- a/src/arroyo/listener.py
+++ b/src/arroyo/listener.py
@@ -1,11 +1,7 @@
 from abc import ABC, abstractmethod
 
-from .operator import Operator
-
 
 class Listener(ABC):
-
-    operator: Operator
 
     @abstractmethod
     async def start(self) -> None:

--- a/src/arroyo/operator.py
+++ b/src/arroyo/operator.py
@@ -1,24 +1,31 @@
 from abc import ABC, abstractmethod
 from typing import List
 
+from .listener import Listener
 from .publisher import Publisher
 from .schemas import Message
 
 
 class Operator(ABC):
-
-    publisher: List[Publisher] = []
+    listeners: List[Listener] = []
+    publishers: List[Publisher] = []
 
     @abstractmethod
     async def process(self, message: Message) -> None:
         pass
 
+    def add_listener(self, listener: Listener) -> None: # noqa
+        self.listeners.append(listener)
+
+    def remove_listener(self, listener: Listener) -> None: # noqa
+        self.listeners.remove(listener)
+
     def add_publisher(self, publisher: Publisher) -> None:
-        self.publisher.append(publisher)
+        self.publishers.append(publisher)
 
     def remove_publisher(self, publisher: Publisher) -> None:
-        self.publisher.remove(publisher)
+        self.publishers.remove(publisher)
 
     async def publish(self, message: Message) -> None:
-        for publisher in self.publisher:
+        for publisher in self.publishers:
             await publisher.publish(message)

--- a/src/arroyo/redis.py
+++ b/src/arroyo/redis.py
@@ -1,55 +1,75 @@
 import asyncio
 import logging
 
-
-from redis.asyncio import Redis
-
+from redis.asyncio.client import Redis
 
 from .listener import Listener
 from .operator import Operator
 
-
 logger = logging.getLogger("arroyo.zmq")
-
-REDIS_CHANNEL_NAME = b"arroyo"
 
 
 class RedisListener(Listener):
 
     def __init__(
             self,
-            operator: Operator,
             redis_client: Redis,
-            redis_pubsub: Redis.pubsub):
+            redis_channel_name: str,
+            operator: Operator):
 
-        self.operator = operator
         self.stop_requested = False
         self.redis_client: Redis = redis_client
-        self.redis_pub_sub = redis_pubsub
+        self.redis_channel_name = redis_channel_name
+        self.operator = operator
 
     @classmethod
     async def from_client(
             cls,
-            operator: Operator,
             redis_client: Redis,
-            redis_pub_sub):
-        return RedisListener(operator, redis_client, redis_pub_sub)
+            redis_channel_name: str,
+            operator: Operator):
+        return RedisListener(redis_client, redis_channel_name, operator)
 
     async def start(self):
         logger.info("Listener started")
+        pubsub = self.redis_client.pubsub()
+        await pubsub.subscribe(self.redis_channel_name)
+        # Listen for messages in the subscribed channel
         while True:
             if self.stop_requested:
                 return
             # get_message blocks until timeout, returning None if no message in that time
-            raw_msg = await self.redis_pub_sub.get_message(ignore_subscribe_messages=True, timeout=1.0)
+            raw_msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
             if raw_msg is None:
                 continue
             msg = raw_msg['data']
             if logger.getEffectiveLevel() == logging.DEBUG:
                 logger.debug(f"{msg=}")
-            await self.operator.process(msg)     
+            await self.operator.process(msg)
 
     async def stop(self):
         self.stop_requested = True
-        self.redis_pub_sub.aclose()
-        self.redis_client.aclose()
+        await self.redis_client.aclose()
+
+
+class RedisPublisher:
+
+    def __init__(
+            self,
+            redis_client: Redis,
+            redis_channel_name: str):
+
+        self.redis_client: Redis = redis_client
+        self.redis_channel_name = redis_channel_name
+
+    @classmethod
+    async def from_client(
+            cls,
+            redis_client: Redis,
+            redis_channel_name: str):
+        return RedisPublisher(redis_client, redis_channel_name)
+
+    async def publish(self, message):
+        await self.redis_client.publish(self.redis_channel_name, message)
+        if logger.getEffectiveLevel() == logging.DEBUG:
+            logger.debug(f"Published {message=}")


### PR DESCRIPTION
This PR simplifies the redis code by removing the unnecessary injection of pub_sub objects, replacing it with channel name.